### PR TITLE
feat: 增加多个应用规则

### DIFF
--- a/src/apps/com.alibaba.android.rimet.ts
+++ b/src/apps/com.alibaba.android.rimet.ts
@@ -1,0 +1,16 @@
+import { defineAppConfig } from '../types';
+
+export default defineAppConfig({
+  id: 'com.alibaba.android.rimet',
+  name: '钉钉',
+  groups: [
+    {
+      key: 0,
+      name: '开屏广告',
+      activityIds: 'com.alibaba.android.rimet.biz.SplashActivity',
+      rules:
+        '[id="com.alibaba.android.rimet:id/btn_check_detail"||text^="跳过"]',
+      snapshotUrls: 'https://gkd-kit.songe.li/import/12506211',
+    },
+  ],
+});

--- a/src/apps/com.baidu.duer.superapp.ts
+++ b/src/apps/com.baidu.duer.superapp.ts
@@ -1,0 +1,15 @@
+import { defineAppConfig } from '../types';
+
+export default defineAppConfig({
+  id: 'com.baidu.duer.superapp',
+  name: '小度',
+  groups: [
+    {
+      key: 0,
+      name: '开屏广告',
+      activityIds: 'com.baidu.duer.superapp.splash.SplashActivity',
+      rules: '[id="com.byted.pangle:id/tt_splash_skip_btn"]',
+      snapshotUrls: 'https://gkd-kit.gitee.io/import/12506571',
+    },
+  ],
+});

--- a/src/apps/com.douban.frodo.ts
+++ b/src/apps/com.douban.frodo.ts
@@ -7,11 +7,15 @@ export default defineAppConfig({
     {
       key: 0,
       name: '开屏广告',
-      activityIds: 'com.douban.frodo.activity.SplashActivity',
+      activityIds: [
+        'com.douban.frodo.activity.SplashActivity',
+        'com.douban.frodo.splash.SplashActivityHot',
+      ],
       rules: '[id="com.douban.frodo:id/skip"||text^="跳过"]',
       snapshotUrls: [
         'https://gkd-kit.gitee.io/import/12505151',
         'https://gkd-kit.gitee.io/import/12505152',
+        'https://gkd-kit.gitee.io/import/12506164',
       ],
     },
   ],

--- a/src/apps/com.heytap.market.ts
+++ b/src/apps/com.heytap.market.ts
@@ -1,0 +1,17 @@
+import { defineAppConfig } from '../types';
+
+export default defineAppConfig({
+  id: 'com.heytap.market',
+  name: '软件商店',
+  groups: [
+    {
+      key: 0,
+      name: '开屏广告',
+      activityIds:
+        'com.heytap.cdo.client.cards.page.main.maintab.MainTabActivity',
+      rules:
+        '[id="android:id/content"] > RelativeLayout > LinearLayout > [text="跳过"]',
+      snapshotUrls: 'https://gkd-kit.gitee.io/import/12506561',
+    },
+  ],
+});

--- a/src/apps/com.koudai.weidian.buyer.ts
+++ b/src/apps/com.koudai.weidian.buyer.ts
@@ -1,0 +1,15 @@
+import { defineAppConfig } from '../types';
+
+export default defineAppConfig({
+  id: 'com.koudai.weidian.buyer',
+  name: '微店',
+  groups: [
+    {
+      key: 0,
+      name: '开屏广告',
+      activityIds: 'com.koudai.weidian.buyer.activity.SplashActivity',
+      rules: '[id="com.koudai.weidian.buyer:id/skip_view"||text="跳过"]',
+      snapshotUrls: 'https://gkd-kit.songe.li/import/12506297',
+    },
+  ],
+});

--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -2,7 +2,7 @@ import { defineAppConfig } from '../types';
 
 export default defineAppConfig({
   id: 'com.tencent.mm',
-  name: `微信`,
+  name: '微信',
   groups: [
     {
       key: 0,
@@ -10,32 +10,50 @@ export default defineAppConfig({
       desc: '朋友圈信息流广告,点击关闭按钮,确认关闭',
       activityIds: 'com.tencent.mm.plugin.sns.ui.SnsTimeLineUI',
       exampleUrls: [
-        `https://github.com/gkd-kit/subscription/assets/38517192/c9ae4bba-a748-4755-b5e4-c7ad3d489a79`,
+        'https://github.com/gkd-kit/subscription/assets/38517192/c9ae4bba-a748-4755-b5e4-c7ad3d489a79',
       ],
       rules: [
-        'TextView[text*=`广告`] + TextView[text=`关闭该广告`]',
-        'ImageView - TextView[text=`广告`][id!=null][index=0]',
+        'TextView[text*="广告"] + TextView[text="关闭该广告"]',
+        'ImageView - TextView[text="广告"][id!=null][index=0]',
       ],
     },
     {
       key: 1,
       name: '电脑微信快捷自动登录',
       activityIds: '.plugin.webwx.ui.ExtDeviceWXLoginUI',
-      rules: 'TextView[text=`取消登录`] - Button[text=`登录`]',
+      rules: 'TextView[text="取消登录"] - Button[text="登录"]',
     },
     {
       key: 2,
       name: '浏览器扫码微信登录自动授权',
       activityIds: ['com.tencent.mm.plugin.webview.ui.tools.SDKOAuthUI'],
-      rules: 'Button[text=`拒绝`] - Button[text=`允许`]',
+      rules: 'Button[text="拒绝"] - Button[text="允许"]',
     },
     {
       key: 3,
       name: '微信手机第三方APP申请使用',
       desc: '自动点击同意',
       rules: [
-        'TextView + TextView[text=`申请使用`]',
-        'Button[text=`拒绝`] - Button[text=`允许`]',
+        'TextView + TextView[text="申请使用"]',
+        'Button[text="拒绝"] - Button[text="允许"]',
+      ],
+    },
+    {
+      key: 4,
+      name: '微信读书网页版扫码登录自动授权',
+      activityIds: ['com.tencent.mm.plugin.webview.ui.tools.MMWebViewUI'],
+      rules: [
+        {
+          matches: 'Button[text="登 录"]',
+          snapshotUrls: 'https://gkd-kit.songe.li/import/12506197',
+        },
+        {
+          matches: [
+            '[text="登录成功"]',
+            '[id="com.tencent.mm:id/g1"][desc="返回"]',
+          ],
+          snapshotUrls: 'https://gkd-kit.songe.li/import/12506201',
+        },
       ],
     },
   ],

--- a/src/apps/com.xiachufang.ts
+++ b/src/apps/com.xiachufang.ts
@@ -5,25 +5,15 @@ export default defineAppConfig({
   name: '下厨房',
   groups: [
     {
-      key: 1,
+      key: 0,
       name: '开屏广告',
       activityIds: ['com.xiachufang.startpage.ui.StartPageActivity'],
-      rules: [
-        {
-          matches: '[id$="/tt_splash_skip_btn"]',
-          snapshotUrls: ['https://gkd-kit.songe.li/import/12505985'],
-        },
-        {
-          matches: '[id$="/start_page_count_down_tv"]',
-          snapshotUrls: ['https://gkd-kit.songe.li/import/12506014'],
-        },
-        {
-          matches: '[text$="跳过"]',
-          snapshotUrls: [
-            'https://gkd-kit.songe.li/import/12506014',
-            'https://gkd-kit.songe.li/import/12506041',
-          ],
-        },
+      rules:
+        '[id$="/tt_splash_skip_btn"||id$="/start_page_count_down_tv"||text$="跳过"]',
+      snapshotUrls: [
+        'https://gkd-kit.songe.li/import/12505985',
+        'https://gkd-kit.songe.li/import/12506014',
+        'https://gkd-kit.songe.li/import/12506041',
       ],
     },
   ],

--- a/src/apps/com.xiachufang.ts
+++ b/src/apps/com.xiachufang.ts
@@ -1,0 +1,30 @@
+import { defineAppConfig } from '../types';
+
+export default defineAppConfig({
+  id: 'com.xiachufang',
+  name: '下厨房',
+  groups: [
+    {
+      key: 1,
+      name: '开屏广告',
+      activityIds: ['com.xiachufang.startpage.ui.StartPageActivity'],
+      rules: [
+        {
+          matches: '[id$="/tt_splash_skip_btn"]',
+          snapshotUrls: ['https://gkd-kit.songe.li/import/12505985'],
+        },
+        {
+          matches: '[id$="/start_page_count_down_tv"]',
+          snapshotUrls: ['https://gkd-kit.songe.li/import/12506014'],
+        },
+        {
+          matches: '[text$="跳过"]',
+          snapshotUrls: [
+            'https://gkd-kit.songe.li/import/12506014',
+            'https://gkd-kit.songe.li/import/12506041',
+          ],
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Closes #2 

规则可能写得不够细，不太了解安卓开屏广告直接用 `[text="跳过"]` 定位会有多少误操作率。

有个建议是能不能把本地规则文件中的反引号都改成单引号，因为反引号没办法直接复制粘贴到内存订阅中测试。