### PR TITLE
fix(百度地图)

### DIFF
--- a/src/apps/com.baidu.BaiduMap.ts
+++ b/src/apps/com.baidu.BaiduMap.ts
@@ -17,8 +17,12 @@ export default defineAppConfig({
       key: 1,
       name: '地图上方黄页横幅',
       activityIds: 'com.baidu.baidumaps.MapsActivity',
-      rules: '[id="com.baidu.BaiduMap:id/yellow_banner_close"][desc="关闭"]',
-      snapshotUrls: 'https://gkd-kit.gitee.io/import/12642301',
+      rules:
+        'LinearLayout[id="com.baidu.BaiduMap:id/switcher_layout_banner"] > [id="com.baidu.BaiduMap:id/yellow_banner_close"][desc="关闭"]',
+      snapshotUrls: [
+        'https://gkd-kit.gitee.io/import/12642301',
+        'https://gkd-kit.gitee.io/import/12801465',
+      ],
     },
     {
       key: 2,


### PR DESCRIPTION
- 在此 [快照](https://gkd-kit.gitee.io/import/12801465) 下原有的 _“地图上方黄页横幅”_ 规则会误点击上方的 _“节假日期间营业状态和时间可能变动，请以当地公告为准”_ 横幅，进入其他页面