### PR TITLE
fix(华为音乐)

### DIFF
--- a/src/apps/com.huawei.music.ts
+++ b/src/apps/com.huawei.music.ts
@@ -121,7 +121,7 @@ export default defineAppConfig({
       activityIds: ['com.android.mediacenter.MainActivity'],
       rules: [
         {
-          matches: 'ViewGroup > TextView[text="广告"]',
+          matches: 'ViewGroup > TextView[text="广告"][id$="ad_icon"]',
           snapshotUrls: ['https://gkd-kit.gitee.io/import/13068935'],
         },
       ],

--- a/src/apps/com.huawei.music.ts
+++ b/src/apps/com.huawei.music.ts
@@ -122,7 +122,10 @@ export default defineAppConfig({
       rules: [
         {
           matches: 'ViewGroup > TextView[text="广告"][id$="ad_icon"]',
-          snapshotUrls: ['https://gkd-kit.gitee.io/import/13068935'],
+          snapshotUrls: [
+            'https://gkd-kit.gitee.io/import/13068935',
+            'https://gkd-kit.gitee.io/import/13194163', // 避免在此规则误触
+          ],
         },
       ],
     },


### PR DESCRIPTION
- 华为音乐：fix在 https://gkd-kit.gitee.io/import/13194163 快照下"播放器上滑广告"规则误触