### PR TITLE
feat(向日葵远程控制):版本更新

### DIFF
--- a/src/apps/com.oray.sunlogin.ts
+++ b/src/apps/com.oray.sunlogin.ts
@@ -22,7 +22,7 @@ export default defineAppConfig({
       quickFind: true,
       rules: [
         {
-          matches: ['[text="最新版本为"]', '[text="以后再说"]'],
+          matches: ['[text *="最新版本为"]', '[text="以后再说"]'],
           snapshotUrls: 'https://i.gkd.li/import/13195560',
         },
       ],

--- a/src/apps/com.oray.sunlogin.ts
+++ b/src/apps/com.oray.sunlogin.ts
@@ -22,7 +22,8 @@ export default defineAppConfig({
       quickFind: true,
       rules: [
         {
-          matches: ['[text *="最新版本为"]', '[text="以后再说"]'],
+          matches:
+            '[text="立即更新"] <2 * > [id="com.oray.sunlogin:id/button_cancel"][text="以后再说"]',
           snapshotUrls: 'https://i.gkd.li/import/13195560',
         },
       ],

--- a/src/apps/com.oray.sunlogin.ts
+++ b/src/apps/com.oray.sunlogin.ts
@@ -16,5 +16,16 @@ export default defineAppConfig({
       exampleUrls:
         'https://github.com/gkd-kit/inspect/assets/38517192/61d335f0-a85a-4e26-80fe-6bc0d1742bc0',
     },
+    {
+      key: 1,
+      name: '版本更新',
+      quickFind: true,
+      rules: [
+        {
+          matches:['[text="最新版本为"]','[text="以后再说"]'],
+          snapshotUrls: 'https://i.gkd.li/import/13195560',
+        },
+      ],
+    },
   ],
 });

--- a/src/apps/com.oray.sunlogin.ts
+++ b/src/apps/com.oray.sunlogin.ts
@@ -22,7 +22,7 @@ export default defineAppConfig({
       quickFind: true,
       rules: [
         {
-          matches:['[text="最新版本为"]','[text="以后再说"]'],
+          matches: ['[text="最新版本为"]', '[text="以后再说"]'],
           snapshotUrls: 'https://i.gkd.li/import/13195560',
         },
       ],


### PR DESCRIPTION
- 【版本更新】#1506 


`matches: ['[text *="最新版本为"]', '[text="以后再说"]'],`

`[id="com.oray.sunlogin:id/text_title"][text ^="最新版本为"] +2 LinearLayout [id="com.oray.sunlogin:id/button_cancel"][text="以后再说"]`

@lisonge 
大佬这两种规则模式，更推荐哪一种，
规则一 类似李跳跳的自定义规则，gkd是否考虑在本地增设类似的自定义添加模式
[快照](https://i.gkd.li/import/13195560)


![222](https://github.com/gkd-kit/subscription/assets/39406781/cec1e95a-98d5-4822-84f0-f9a52b992d75)
