### PR TITLE
feat(三星应用商店):开屏广告

### DIFF
--- a/src/apps/com.sec.android.app.samsungapps.ts
+++ b/src/apps/com.sec.android.app.samsungapps.ts
@@ -7,11 +7,16 @@ export default defineAppConfig({
     {
       key: 1,
       name: '开屏广告',
-      activityIds: ['com.sec.android.app.samsungapps.notipopup.WebViewPopup'],
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'app',
       rules: [
         {
           matches: '[id="com.sec.android.app.samsungapps:id/skip"]',
-          snapshotUrls: ['https://i.gkd.li/import/12674484'],
+          snapshotUrls: [
+            'https://i.gkd.li/import/12674484',
+            'https://i.gkd.li/import/13324391',
+          ],
         },
       ],
     },


### PR DESCRIPTION
- 【开屏广告】 #2008 

- 为什么相似的快照，有的支持quickFind，有的不支持

  [不支持quickFind的快照](https://i.gkd.li/import/12674484)
  ![image](https://github.com/gkd-kit/subscription/assets/39406781/bc841f82-8191-46a4-b463-2fa5e70cb29b)
 
  [支持quickFind的快照](https://i.gkd.li/import/13324391)
  ![image](https://github.com/gkd-kit/subscription/assets/39406781/ce93fe8d-e0d1-4c05-a957-41b7d2fc2536)


 
- 以下微博轻享版也是`TextView[text^="跳过"][text.length<10]`
 [支持quickFind](https://i.gkd.li/import/13328397)
 [不支持quickFind](https://i.gkd.li/import/12510132)

- #2003 