### PR TITLE
feat(浙里办):开屏宣传

### DIFF
--- a/src/apps/com.hanweb.android.zhejiang.activity.ts
+++ b/src/apps/com.hanweb.android.zhejiang.activity.ts
@@ -5,8 +5,9 @@ export default defineAppConfig({
   name: '浙里办',
   groups: [
     {
+      enable: false, // 政务app，首页涉及民生政策宣传及服务快捷入口，默认关闭
       key: 0,
-      name: '开屏广告',
+      name: '开屏宣传',
       quickFind: true,
       matchTime: 10000,
       actionMaximum: 1,


### PR DESCRIPTION
设置key0【开屏宣传】默认关闭，
理由：民生政务app，首页涉及民生政策宣传及服务快捷入口，非营利广告