### PR TITLE
feat(微信):规则优化

### DIFF
--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -288,7 +288,7 @@ export default defineAppConfig({
       quickFind: true,
       matchTime: 10000,
       // actionMaximum: 1, // 经常需要点2次，首次点击过早大概率跳不过
-      resetMatch: 'activity',
+      // resetMatch: 'activity',
       activityIds: [
         'com.tencent.mm.plugin.appbrand.ui.AppBrandUI',
         'com.tencent.mm.plugin.appbrand.launching.AppBrandLaunchProxyUI',

--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -287,7 +287,7 @@ export default defineAppConfig({
       name: '微信小程序-开屏广告',
       quickFind: true,
       matchTime: 10000,
-      actionMaximum: 1,
+      // actionMaximum: 1, // 经常需要点2次，首次点击过早大概率跳不过
       resetMatch: 'activity',
       activityIds: [
         'com.tencent.mm.plugin.appbrand.ui.AppBrandUI',
@@ -295,6 +295,7 @@ export default defineAppConfig({
       ],
       rules: [
         {
+          actionDelay: 800, // 过早点击首次大概率跳不过
           matches: [
             'FrameLayout > TextView + FrameLayout > TextView[text="广告"]',
             'FrameLayout > TextView + FrameLayout > TextView[text="跳过"]',

--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -434,5 +434,16 @@ export default defineAppConfig({
         ],
       },
     },
+    {
+      key: 17,
+      name: '青少年模式弹窗',
+      quickFind: true,
+      actionMaximum: 1,
+      resetMatch: 'app',
+      activityIds: 'com.tencent.mm.plugin.finder.ui.FinderSelfUI',
+      rules:
+        'TextView[text^="为呵护未成年人健康成长，微信推出青少年模式"] +2 Button[text="我知道了"]',
+      snapshotUrls: 'https://i.gkd.li/import/13538145',
+    },
   ],
 });

--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -97,14 +97,29 @@ export default defineAppConfig({
       enable: false,
       key: 1,
       name: '电脑微信快捷自动登录',
-      activityIds: '.plugin.webwx.ui.ExtDeviceWXLoginUI',
+      quickFind: true,
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'activity',
+      activityIds: [
+        '.plugin.webwx.ui.ExtDeviceWXLoginUI',
+        'com.tencent.mm.ui.LauncherUI',
+      ],
       rules: 'TextView[text="取消登录"] - Button[text="登录"]',
+      snapshotUrls: [
+        'https://i.gkd.li/import/13522625', // activityIds: 'com.tencent.mm.plugin.webwx.ui.ExtDeviceWXLoginUI'
+        'https://i.gkd.li/import/13522577', // activityIds: 'com.tencent.mm.ui.LauncherUI'
+      ],
     },
     {
       enable: false,
       key: 2,
       name: '浏览器扫码微信登录自动授权',
       desc: '自动允许使用头像昵称等',
+      quickFind: true,
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'activity',
       activityIds: [
         'com.tencent.mm.plugin.webview.ui.tools.SDKOAuthUI',
         'com.tencent.mm.ui.LauncherUI',
@@ -117,6 +132,10 @@ export default defineAppConfig({
       key: 3,
       name: '第三方APP申请使用授权弹窗',
       desc: '自动点击允许,但由于此界面可以额外新建昵称头像,默认不启用',
+      quickFind: true,
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'activity',
       activityIds: ['com.tencent.mm.plugin.base.stub.UIEntryStub'],
       rules: 'Button[text="拒绝"] - Button[text="允许"]',
       snapshotUrls: 'https://i.gkd.li/import/12663602',
@@ -125,6 +144,10 @@ export default defineAppConfig({
       enable: false,
       key: 4,
       name: '微信读书网页版扫码登录自动授权',
+      quickFind: true,
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'activity',
       activityIds: ['com.tencent.mm.plugin.webview.ui.tools.MMWebViewUI'],
       rules: [
         {
@@ -221,6 +244,7 @@ export default defineAppConfig({
       key: 7,
       name: '自动选中发送原图',
       desc: '图片和视频选择器-自动选中底部中间的发送原图',
+      quickFind: true,
       activityIds: [
         'com.tencent.mm.plugin.gallery.ui.AlbumPreviewUI',
         'com.tencent.mm.plugin.gallery.ui.ImagePreviewUI',
@@ -228,7 +252,7 @@ export default defineAppConfig({
       rules: [
         {
           key: 1,
-          matches: '[text="原图"] - ImageButton[desc="未选中,原图,复选框"]',
+          matches: '@ImageButton[desc="未选中,原图,复选框"] + [text="原图"]',
           snapshotUrls: [
             'https://i.gkd.li/import/12686641', // 未选中
             'https://i.gkd.li/import/12840865', // 未选中
@@ -278,9 +302,10 @@ export default defineAppConfig({
       key: 9,
       name: '自动查看原图',
       desc: '自动点击底部左侧[查看原图（*M）]按钮',
+      quickFind: true,
       activityIds: 'com.tencent.mm.ui.chatting.gallery.ImageGalleryUI',
       rules: 'Button[text^="查看原图"][clickable=true]',
-      snapshotUrls: 'https://i.gkd.li/import/12706944',
+      snapshotUrls: 'https://i.gkd.li/import/13523031',
     },
     {
       key: 10,
@@ -317,6 +342,9 @@ export default defineAppConfig({
       key: 11,
       name: '网页版文件传输助手扫码自动授权',
       quickFind: true,
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'activity',
       activityIds: 'com.tencent.mm.ui.LauncherUI',
       rules: '[text="打开网页版文件传输助手"] + * > Button[text="打开"]',
       snapshotUrls: 'https://i.gkd.li/import/12793745',


### PR DESCRIPTION
**故障**：小程序开屏广告经常需要点击2次，第1次点击太早无法跳过
处理：加入`actionDelay:800`,使其尽量首次跳过，并删除`actionMaximum:1,resetMatch: 'activity',`，以免仍需2次点击
- #2750 
- #2748 
- #2742 

**规则优化**
存在个别快照版本更新
- #2773 