### PR TITLE
feat(财联社): 优化开屏广告,添加首页弹窗广告

### DIFF
--- a/src/apps/com.lanjinger.choiassociatedpress.ts
+++ b/src/apps/com.lanjinger.choiassociatedpress.ts
@@ -3,16 +3,31 @@ import { defineAppConfig } from '../types';
 export default defineAppConfig({
   id: 'com.lanjinger.choiassociatedpress',
   name: '财联社',
+  quickFind: true,
   groups: [
     {
       key: 0,
       name: '开屏广告',
       matchTime: 10000,
-      quickFind: true,
       resetMatch: 'app',
+      enable: true,
+      activityIds: 'com.lanjinger.choiassociatedpress.ad.AdActivity',
       actionMaximum: 1,
-      rules: '[id="com.lanjinger.choiassociatedpress:id/iv_skip"]',
-      snapshotUrls: 'https://i.gkd.li/import/13627807',
+      rules: '[text="跳过"]',
+      snapshotUrls: [
+        'https://i.gkd.li/import/13627807',
+        'https://i.gkd.li/import/13748989',
+      ],
+    },
+    {
+      key: 1,
+      name: '首页-弹窗广告',
+      matchTime: 10000,
+      actionMaximum: 1,
+      enable: false,
+      activityIds: 'com.lanjinger.choiassociatedpress.main.OperateActivity',
+      rules: '@ImageView[id$="iv_back"][clickable=true]',
+      snapshotUrls: 'https://i.gkd.li/import/13749206',
     },
   ],
 });


### PR DESCRIPTION
财联社开屏广告的弹窗规则已经改变，快照：<https://i.gkd.li/import/13748989>，不过看到旧的提交是两周前，考虑到兼容问题，使用了`[text="跳过"]`来进行匹配；另外添加了首页的弹窗规则。