### PR TITLE
fix(b站)系统在繁体中文下失效

### DIFF
--- a/src/apps/tv.danmaku.bili.ts
+++ b/src/apps/tv.danmaku.bili.ts
@@ -13,7 +13,7 @@ export default defineAppConfig({
       matchTime: 10000,
       actionMaximum: 1,
       resetMatch: 'app',
-      rules: '[id="tv.danmaku.bili:id/count_down"][text^="跳过"]',
+      rules: '[id="tv.danmaku.bili:id/count_down"]',
       snapshotUrls: 'https://i.gkd.li/import/12705270',
     },
     {


### PR DESCRIPTION
去掉 text^="跳过"，解决b站开屏广告在繁体系统下失效问题