### PR TITLE
feat(华为手机管家): 风险提示-继续使用-取消移入管控

### DIFF
--- a/src/apps/com.huawei.systemmanager.ts
+++ b/src/apps/com.huawei.systemmanager.ts
@@ -1,0 +1,40 @@
+import { defineAppConfig } from '../types';
+
+export default defineAppConfig({
+  id: 'com.huawei.systemmanager',
+  name: '华为手机管家',
+  groups: [
+    {
+      key: 1,
+      name: '风险提示-继续使用',
+      rules: [
+        {
+          matches: '[id="com.huawei.systemmanager:id/virus_checkbox"]',
+          snapshotUrls: [
+            'https://i.gkd.li/snapshot/1704046524559',
+            'https://i.gkd.li/snapshot/1704044291821',
+          ],
+        },
+        {
+          matches: '[id="android:id/button2"]',
+          snapshotUrls: [
+            'https://i.gkd.li/snapshot/1704046524559',
+            'https://i.gkd.li/snapshot/1704044291821',
+          ],
+        },
+      ],
+    },
+    {
+      key: 2,
+      name: '移入管控-取消',
+      rules: [
+        {
+          matches: '[id="android:id/button2"]',
+          snapshotUrls: [
+            'https://i.gkd.li/snapshot/1704044583264',
+          ],
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
适用于使用了冻结类工具，并且使用了会弹出风险提示的app，的情况
每次解冻使用这些app都会重新出现风险提示弹窗
故尝试自动关闭