### PR TITLE
feat(全局规则):开屏广告-字节穿山甲广告SDK

### DIFF
--- a/src/globalGroups.ts
+++ b/src/globalGroups.ts
@@ -47,6 +47,17 @@ const globalGroups: RawGlobalGroup[] = [
         matches:
           '[childCount=0][visibleToUser=true][(text.length<10&&(text*="跳过"||text*="跳過"||text*="skip"||text*="Skip")) || id$="tt_splash_skip_btn" || vid*="skip" || vid*="Skip" || (vid*="count" && vid*="down" && vid!*="download") || desc*="跳过" || desc*="skip"]',
       },
+      {
+        key: 2,
+        name: '字节穿山甲广告SDK',
+        matches:
+          'FrameLayout > FrameLayout[childCount>2] > @View[clickable=true] + TextView',
+        snapshotUrls: [
+          'https://i.gkd.li/import/13855760',
+          'https://i.gkd.li/import/13840775',
+          'https://i.gkd.li/import/13855443',
+        ],
+      },
     ],
     apps: diabledAppIds.map((id) => ({ id, enable: false })),
   },


### PR DESCRIPTION
以下pr中的`开屏广告`均使用字节广告SDK，可使用通用规则
`FrameLayout > FrameLayout[childCount>2] > @View[clickable=true] + TextView`
- #3785 
- #3715 
- #3740 
- #3746 
- #3769
- #3784 
- #3786 
- #3798 
- #3807 
- #3820 